### PR TITLE
각 스킬 별 테스트 및 쿨타임 초기화 수정

### DIFF
--- a/Assets/Game/Project/Data/Skills/Mana Arcane.asset
+++ b/Assets/Game/Project/Data/Skills/Mana Arcane.asset
@@ -19,11 +19,11 @@ MonoBehaviour:
   rarity: 2
   description: "\uBD80\uCC44\uAF34 \uBC29\uC2DD \uC2A4\uD0AC"
   equippedRunes: []
-  damage: 7
+  damage: 5
   speed: 12
   range: 32
   lifeTime: 3
-  cooldown: 1.5
+  cooldown: 3
   scale: 1
   critChance: 0.05
   critDamage: 1.5

--- a/Assets/Game/Project/Data/Skills/Mana Bounce.asset
+++ b/Assets/Game/Project/Data/Skills/Mana Bounce.asset
@@ -20,15 +20,15 @@ MonoBehaviour:
   description: "\uCDA9\uB3CC \uC2DC \uD22C\uC0AC\uCCB4\uAC00 \uD295\uAE30\uB294 \uC2A4\uD0AC"
   equippedRunes: []
   damage: 7
-  speed: 12
+  speed: 16
   range: 32
   lifeTime: 3
-  cooldown: 1.5
+  cooldown: 2
   scale: 1
   critChance: 0.05
   critDamage: 1.5
   chargeTime: 0.2
-  projectileCount: 3
+  projectileCount: 1
   acceleration: 0
   homingStrength: 0
   areaRadius: 1

--- a/Assets/Game/Project/Data/Skills/Mana Growing.asset
+++ b/Assets/Game/Project/Data/Skills/Mana Growing.asset
@@ -23,8 +23,8 @@ MonoBehaviour:
   damage: 15
   speed: 12
   range: 20
-  lifeTime: 3
-  cooldown: 1.5
+  lifeTime: 4
+  cooldown: 3
   scale: 1
   critChance: 0.05
   critDamage: 1.5

--- a/Assets/Game/Project/Data/Skills/Mana Linear.asset
+++ b/Assets/Game/Project/Data/Skills/Mana Linear.asset
@@ -19,16 +19,16 @@ MonoBehaviour:
   rarity: 2
   description: "\uC9C1\uC120\uC73C\uB85C \uB0A0\uC544\uAC00\uB294 \uC2A4\uD0AC"
   equippedRunes: []
-  damage: 7
+  damage: 10
   speed: 24
   range: 20
   lifeTime: 3
-  cooldown: 1
+  cooldown: 3
   scale: 1
   critChance: 0.05
   critDamage: 1.5
   chargeTime: 0.2
-  projectileCount: 0
+  projectileCount: 1
   acceleration: 0
   homingStrength: 0
   areaRadius: 1

--- a/Assets/Game/Project/Data/Skills/Mana Rifle.asset
+++ b/Assets/Game/Project/Data/Skills/Mana Rifle.asset
@@ -20,16 +20,16 @@ MonoBehaviour:
   description: "\uC5EC\uB7EC \uD22C\uC0AC\uCCB4\uB97C \uAC04\uACA9\uC5D0 \uB9DE\uCDB0
     \uB098\uAC00\uB294 \uC2A4\uD0AC"
   equippedRunes: []
-  damage: 5
+  damage: 3
   speed: 16
-  range: 20
+  range: 8
   lifeTime: 3
-  cooldown: 0.4
+  cooldown: 1.5
   scale: 1
   critChance: 0.05
   critDamage: 1.5
-  chargeTime: 0.2
-  projectileCount: 0
+  chargeTime: 0.1
+  projectileCount: 3
   acceleration: 0
   homingStrength: 0
   areaRadius: 1

--- a/Assets/Game/Project/Data/Skills/Mana Spin.asset
+++ b/Assets/Game/Project/Data/Skills/Mana Spin.asset
@@ -20,11 +20,11 @@ MonoBehaviour:
   description: "\uCDA9\uB3CC \uC9C0\uC810\uC5D0 \uC9C0\uC18D \uB300\uBBF8\uC9C0\uC8FC\uB294
     \uC2A4\uD0AC"
   equippedRunes: []
-  damage: 7
+  damage: 3
   speed: 12
-  range: 32
+  range: 7
   lifeTime: 3
-  cooldown: 1.5
+  cooldown: 3
   scale: 1
   critChance: 0.05
   critDamage: 1.5

--- a/Assets/Game/Project/Scenes/2. Lobby.unity
+++ b/Assets/Game/Project/Scenes/2. Lobby.unity
@@ -1527,7 +1527,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   equippedSkills:
-  - {fileID: 11400000, guid: 23ef8d618101f3943aaae39940f9a413, type: 2}
+  - {fileID: 11400000, guid: a629d224a2c175348a13463821863b73, type: 2}
+  - {fileID: 11400000, guid: fc3f1eae790f199418850d58030364b7, type: 2}
+  - {fileID: 11400000, guid: bf509869729b16342813cf3f2c2fcc80, type: 2}
   firePoint: {fileID: 1670178683}
 --- !u!114 &736989202
 MonoBehaviour:
@@ -1641,7 +1643,7 @@ MonoBehaviour:
     maxMoveSpeed: 10
     defense: 0
     damage: 0
-    castingSpeed: 0.5
+    castingSpeed: 0
     critDamage: 0
     critChance: 0
   additionalStat:

--- a/Assets/Game/Project/Scripts/Core/Projectile/ProjectileContext.cs
+++ b/Assets/Game/Project/Scripts/Core/Projectile/ProjectileContext.cs
@@ -24,6 +24,7 @@ namespace Game.Project.Scripts.Core.Projectile
         public float finalScale = 1f; 
         public float finalCritChance;
         public float finalCritDamage;
+        public float finalCooldown;
         public int finalProjectileCount;
 
         public bool isCritical;

--- a/Assets/Game/Project/Scripts/Core/Projectile/SO/SkillData.cs
+++ b/Assets/Game/Project/Scripts/Core/Projectile/SO/SkillData.cs
@@ -25,7 +25,7 @@ namespace Game.Project.Scripts.Core.Projectile.SO
         public float speed = 15f;
         public float range = 20f;
         public float lifeTime = 3f;
-        public float cooldown = 1.0f;
+        public float cooldown = 3.0f;
         public float scale = 1.0f;        //기본 크기 필드
         public float critChance = 0.05f;  //기본 치명타 확률
         public float critDamage = 1.5f;   //기본 치명타 배율

--- a/Assets/Game/Project/Scripts/Core/Projectile/Strategys/Mover/Rifle.cs
+++ b/Assets/Game/Project/Scripts/Core/Projectile/Strategys/Mover/Rifle.cs
@@ -19,12 +19,16 @@ namespace Game.Project.Scripts.Core.Projectile.Strategys.Mover
             _ctx = context;
             projectile.transform.localScale = Vector3.one * _ctx.finalScale;
 
-            float rifleSpread = 3.5f;
-            float randomYaw = Random.Range(-rifleSpread, rifleSpread);
-            float randomPitch = Random.Range(-rifleSpread * 0.5f, rifleSpread * 0.5f);
+            Vector3 targetDir = _ctx.direction;
 
-            Quaternion spreadRotation = Quaternion.Euler(randomPitch, randomYaw, 0);
-            _moveDirection = spreadRotation * _ctx.direction;
+            float intensity = 0.03f;
+            Vector3 randomSpread = new Vector3(
+                Random.Range(-intensity, intensity),
+                Random.Range(-intensity, intensity),
+                Random.Range(-intensity, intensity)
+            );
+
+            _moveDirection = (targetDir + randomSpread).normalized;
 
             if (_moveDirection != Vector3.zero)
                 projectile.transform.rotation = Quaternion.LookRotation(_moveDirection);

--- a/Assets/Game/Project/Scripts/Managers/Singleton/PoolManager.cs
+++ b/Assets/Game/Project/Scripts/Managers/Singleton/PoolManager.cs
@@ -56,7 +56,7 @@ namespace Game.Project.Scripts.Managers.Singleton
             }
 
             Projectile proj = pool.Get();
-            proj.OnReturnToPool = (item) => pool.Release(proj);
+            proj.OnReturnToPool = (item) => pool.Release(item);
             return proj;
         }
         public GameObject GetEffect(GameObject prefab, Vector3 position, Quaternion rotation, Transform parent = null)

--- a/Assets/Game/Project/Scripts/Managers/Singleton/SkillManager.cs
+++ b/Assets/Game/Project/Scripts/Managers/Singleton/SkillManager.cs
@@ -1,3 +1,4 @@
+using Game.Project.Data.Stat;
 using Game.Project.Scripts.Core.Projectile;
 using Game.Project.Scripts.Core.Projectile.Interface;
 using Game.Project.Scripts.Core.Projectile.Rune;
@@ -37,7 +38,12 @@ namespace Game.Project.Scripts.Managers.Singleton
             _moverFactory = new MoverFactory();
             _isInitialized = true;
         }
-
+        public float GetCooldown(SkillData data, Stat playerStat)
+        {
+            ProjectileContext c = new ProjectileContext { data = data };
+            _modifierSystem.ApplyModifiers(c, playerStat);
+            return c.finalCooldown;
+        }
         public void ApplySkill(ProjectileContext prototype)
         {
             if (!_isInitialized) return;

--- a/Assets/Game/Project/Scripts/Managers/Systems/SkillSystems/ModifierSystem.cs
+++ b/Assets/Game/Project/Scripts/Managers/Systems/SkillSystems/ModifierSystem.cs
@@ -4,6 +4,7 @@ using Game.Project.Scripts.Core.Projectile.Rune;
 using Game.Project.Scripts.Core.Projectile.SO;
 using System.Collections;
 using System.Collections.Generic;
+using Unity.VisualScripting;
 using UnityEngine;
 using static Game.Project.Scripts.Managers.Systems.StateSystem;
 
@@ -25,8 +26,11 @@ namespace Game.Project.Scripts.Managers.Systems.SkillSystems
             float skillFinalScale = so.scale; 
             float skillFinalCritChance = so.critChance;
             float skillFinalCritDamage = so.critDamage;
+            float SkillFinalCooldown = so.cooldown;
 
             int skillFinalCount = so.projectileCount;
+
+            float runeCDR = 0f;
 
             if (so.equippedRunes != null)
             {
@@ -58,6 +62,9 @@ namespace Game.Project.Scripts.Managers.Systems.SkillSystems
                         case ModifierType.ProjectileCount:
                             skillFinalCount += (int)rune.specialValue;
                             break;
+                        case ModifierType.Cooldown:
+                            runeCDR += rune.specialValue;
+                            break;
                     }
                 }
             }
@@ -65,6 +72,11 @@ namespace Game.Project.Scripts.Managers.Systems.SkillSystems
             context.finalSpeed = (playerStat.maxMoveSpeed * 0.1f) + skillFinalSpeed;
             context.finalCritChance = playerStat.critChance + skillFinalCritChance;
             context.finalCritDamage = playerStat.critDamage + skillFinalCritDamage;
+
+            float cdAfterRune = SkillFinalCooldown * (1f - runeCDR);
+            float finalCD = cdAfterRune / Mathf.Max(0.1f, 1.0f + playerStat.castingSpeed);
+
+            context.finalCooldown = Mathf.Max(0.05f, finalCD);
 
             context.finalLifeTime = skillFinalLifeTime;
             context.finalRange = so.range;
@@ -77,6 +89,8 @@ namespace Game.Project.Scripts.Managers.Systems.SkillSystems
             context.flyEffect = so.flyEffect;
             context.impactEffect = so.impactEffect;
             context.impactSfx = so.impactSfx;
+
+            Debug.Log($"[Modifier] Final CD: {context.finalCooldown} (Base:{SkillFinalCooldown}, Rune:{runeCDR}, Stat:{playerStat.castingSpeed})");
         }
     }
 }

--- a/Assets/Game/Project/Scripts/Managers/Systems/SkillSystems/SpawnSystem.cs
+++ b/Assets/Game/Project/Scripts/Managers/Systems/SkillSystems/SpawnSystem.cs
@@ -47,7 +47,7 @@ namespace Game.Project.Scripts.Managers.Systems.SkillSystems
                 case MovementType.Linear:
                 case MovementType.Rifle:
                 case MovementType.Bounce:
-                    ctx.direction = Quaternion.Euler(0, finalAngle, 0) * proto.direction;
+                    ctx.direction = proto.direction;
                     break;
 
                 case MovementType.Spin:
@@ -69,16 +69,22 @@ namespace Game.Project.Scripts.Managers.Systems.SkillSystems
                     break;
             }
         }
-        
+
         private IEnumerator FireRifleRoutine(ProjectileContext prototype)
         {
             int totalCount = prototype.finalProjectileCount;
-            float interval = 0.08f;
+
+            float baseInterval = 0.08f;
+            float dynamicInterval = baseInterval * totalCount;
 
             for (int i = 0; i < totalCount; i++)
             {
                 SpawnSingleProjectile(prototype, i, totalCount, null);
-                yield return new WaitForSeconds(interval);
+
+                if (i < totalCount - 1)
+                {
+                    yield return new WaitForSeconds(dynamicInterval);
+                }
             }
         }
         private void SpawnSingleProjectile(ProjectileContext prototype, int index, int total, List<Projectile> list)

--- a/Assets/Game/Project/Scripts/Managers/Systems/StatSystem.cs
+++ b/Assets/Game/Project/Scripts/Managers/Systems/StatSystem.cs
@@ -17,6 +17,8 @@ namespace Game.Project.Scripts.Managers.Systems
 
         private Stat _cachedCurrentStat;
 
+        public event System.Action OnStatChanged;
+
         /// <summary>
         /// 최종 스탯 (Read-only)
         /// </summary>
@@ -36,25 +38,13 @@ namespace Game.Project.Scripts.Managers.Systems
             _isInitialized = true;
             Debug.Log("<color=green>StatSystem: 초기화 및 스탯 캐싱 완료</color>");
         }
-
-        /// <summary>
-        /// 스킬의 공격 간격
-        /// </summary>
-        public float GetFinalAttackInterval(float skillCooldown)
-        {
-            float cdr = _cachedCurrentStat.castingSpeed;
-            float castSpeed = Mathf.Max(0.1f, 1.0f + _cachedCurrentStat.castingSpeed);
-
-            float cooldownAfterCDR = skillCooldown * (1f - cdr);
-            return cooldownAfterCDR / castSpeed;
-        }
-
         /// <summary>
         /// 기본 스탯과 추가 스탯을 합산하여 저장
         /// </summary>
         public void RefreshStat()
         {
             _cachedCurrentStat = CalculateTotalStat(baseStat, additionalStat);
+            OnStatChanged?.Invoke();
         }
 
         /// <summary>
@@ -81,7 +71,7 @@ namespace Game.Project.Scripts.Managers.Systems
         private Stat CalculateTotalStat(Stat a, Stat b)
         {
             Stat result = AddStats(a, b);
-            result.castingSpeed = Mathf.Clamp(result.castingSpeed, 0f, 0.8f);
+            result.castingSpeed = Mathf.Max(0f, result.castingSpeed);
             result.critChance = Mathf.Clamp(result.critChance, 0f, 1.0f);
 
             return result;

--- a/Assets/Game/Project/Scripts/Player/PlayerCombat.cs
+++ b/Assets/Game/Project/Scripts/Player/PlayerCombat.cs
@@ -16,40 +16,89 @@ namespace Game.Project.Scripts.Player
         [SerializeField] private Transform firePoint;
 
         private Dictionary<SkillData, float> _skillTimers = new Dictionary<SkillData, float>();
+        private Dictionary<SkillData, float> _cachedIntervals = new Dictionary<SkillData, float>();
 
         private TargetScanner _scanner;
         private Transform _currentTarget;
 
-        private void Awake() => _scanner = GetComponent<TargetScanner>();
+        private void Awake()
+        {
+            _scanner = GetComponent<TargetScanner>();
+        }
+        private void Start()
+        {
+            if (PlayerManager.Instance.Stats != null)
+            {
+                PlayerManager.Instance.Stats.OnStatChanged += RefreshAllSkill;
+            }
+            RefreshAllSkill();
+        }
+
         private void Update()
         {
+            UpdateTimers(); //쿨타임 계속 업데이트
+
             if (!_scanner.IsTargetValid(_currentTarget))
             {
                 _currentTarget = _scanner.GetClosestTarget();
             }
-            if (_currentTarget == null) return;
-
-            CheckSkills();
+            if (_currentTarget != null)
+            {
+                CheckSkills();
+            }
         }
-
-        private void CheckSkills()
+        private void OnDestroy()
+        {
+            if (PlayerManager.HasInstance && PlayerManager.Instance.Stats != null)
+            {
+                PlayerManager.Instance.Stats.OnStatChanged -= RefreshAllSkill;
+            }
+        }
+        private void UpdateTimers()
         {
             foreach (var skill in equippedSkills)
             {
                 if (skill == null) continue;
                 if (!_skillTimers.ContainsKey(skill)) _skillTimers[skill] = 0f;
-                _skillTimers[skill] += Time.deltaTime;
 
-                float interval = PlayerManager.Instance.Stats.GetFinalAttackInterval(skill.cooldown);
+                float interval = _cachedIntervals.ContainsKey(skill) ? _cachedIntervals[skill] : 0.1f;
+
+                _skillTimers[skill] = Mathf.Min(_skillTimers[skill] + Time.deltaTime, interval);
+            }
+        }
+        private void CheckSkills()
+        {
+            foreach (var skill in equippedSkills)
+            {
+                if (skill == null) continue;
+
+                if (!_cachedIntervals.ContainsKey(skill)) continue;
+                float interval = _cachedIntervals[skill];
 
                 if (_skillTimers[skill] >= interval)
                 {
-                    _skillTimers[skill] = 0f;
+                    _skillTimers[skill] -= interval;
                     AutoAttack(skill);
                 }
             }
         }
+        public void RefreshAllSkill()
+        {
+            _cachedIntervals.Clear();
 
+            foreach (var skill in equippedSkills)
+            {
+                if (skill == null) continue;
+
+                float interval = SkillManager.Instance.GetCooldown(skill, PlayerManager.Instance.Stats.CurrentStat);
+                _cachedIntervals[skill] = interval;
+
+                if (!_skillTimers.ContainsKey(skill))
+                {
+                    _skillTimers[skill] = 0f;
+                }
+            }
+        }
         private void AutoAttack(SkillData skill)
         {
             if (_currentTarget == null) return;
@@ -65,5 +114,18 @@ namespace Game.Project.Scripts.Player
             };
             SkillManager.Instance.ApplySkill(context);
         }
+
+        /// <summary>
+        /// 에디터 전용 콜백
+        /// </summary>
+#if UNITY_EDITOR
+        private void OnValidate()
+        {
+            if (!Application.isPlaying) return;
+            RefreshAllSkill();
+
+            Debug.Log("인스펙터 변경 감지: 스킬 캐시를 갱신했습니다.");
+        }
+#endif
     }
 }

--- a/Assets/Game/Project/Scripts/test/ManaBolt_Data.asset
+++ b/Assets/Game/Project/Scripts/test/ManaBolt_Data.asset
@@ -15,15 +15,15 @@ MonoBehaviour:
   skillName: ManaBolt
   projectilePrefab: {fileID: 923852718690510228, guid: cae6df2aadc771a49b13c4b43b160af9,
     type: 3}
-  movementType: 5
+  movementType: 1
   rarity: 6
   description: "\uD14C\uC2A4\uD2B8\uC6A9 "
   equippedRunes: []
   damage: 1
-  speed: 8
-  range: 7
+  speed: 16
+  range: 8
   lifeTime: 10
-  cooldown: 3
+  cooldown: 1
   scale: 1
   critChance: 0.05
   critDamage: 1.5

--- a/Assets/Game/Project/Utility/Generic/SingletonT.cs
+++ b/Assets/Game/Project/Utility/Generic/SingletonT.cs
@@ -8,6 +8,7 @@ namespace Game.Project.Utillity.Generic
     {
         private static T _instance;
 
+        public static bool HasInstance => _instance != null;
         public static T Instance
         {
             get


### PR DESCRIPTION
1. 플레이어와 스킬 고정 수치의 쿨타임 계산 수정
2. 플레이어 컴뱃의 쿨타임 적용 순서 및 방법 수정
3. 스킬의 라이플 타입 로직 수정
4. 다중 스킬 사용 시 간격,쿨타임 수정 및 적용 테스트